### PR TITLE
Remove assume role from actions

### DIFF
--- a/.github/workflows/tf-merge.yml
+++ b/.github/workflows/tf-merge.yml
@@ -39,7 +39,6 @@ jobs:
         id: bootstrap
         run: |
           python bootstrap.py > ${{ github.workspace }}/${{ github.run_id }}-${{ github.run_number }}.log
-          sed -i '/^assume_role/ d' terraform.tfvars
         working-directory: .
         env:
           TF_WORKSPACE: default
@@ -51,7 +50,6 @@ jobs:
         run: terraform init >> ${{ github.workspace }}/${{ github.run_id }}-${{ github.run_number }}.log
         env:
           TF_WORKSPACE: default
-          TF_VAR_assume_role: ${var.assume_role}
           AWS_DEFAULT_REGION: eu-west-2
 
       - name: "Terraform Apply"
@@ -63,7 +61,6 @@ jobs:
         env:
           TF_WORKSPACE: default
           TF_INPUT: false
-          TF_VAR_assume_role: ${var.assume_role}
           AWS_DEFAULT_REGION: eu-west-2
 
       - name: "Terraform Plan"
@@ -73,7 +70,6 @@ jobs:
         env:
           TF_WORKSPACE: default
           TF_INPUT: false
-          TF_VAR_assume_role: ${var.assume_role}
           AWS_DEFAULT_REGION: eu-west-2
 
       - name: "Redact Logs PROD"

--- a/.github/workflows/tf-pull-request.yml
+++ b/.github/workflows/tf-pull-request.yml
@@ -51,7 +51,6 @@ jobs:
         run: terraform init 
         env:
           TF_WORKSPACE: default
-          TF_VAR_assume_role: ${var.assume_role}
           AWS_DEFAULT_REGION: eu-west-2
 
       - name: "Terraform Plan"
@@ -60,7 +59,6 @@ jobs:
         continue-on-error: false
         env:
           TF_WORKSPACE: default
-          TF_VAR_assume_role: ${var.assume_role}
           AWS_DEFAULT_REGION: eu-west-2
 
       - name: "Redact Logs PROD PR"


### PR DESCRIPTION
The way we get credentials has changed. `assume_role` is no longer required, and could be the cause of issues with secrets.