### PR TITLE
Add branch protection to private repos

### DIFF
--- a/burendo-handbook.tf
+++ b/burendo-handbook.tf
@@ -31,22 +31,20 @@ resource "github_team_repository" "burendo_handbook_admin" {
   permission = "admin"
 }
 
-# Commented out until we establish the Pro license
-# 
-# resource "github_branch_protection" "burendo_handbook_main" {
-#   pattern        = github_repository.burendo_handbook.default_branch
-#   repository_id  = github_repository.burendo_handbook.name
-#   enforce_admins = false
+resource "github_branch_protection" "burendo_handbook_main" {
+  pattern        = github_repository.burendo_handbook.default_branch
+  repository_id  = github_repository.burendo_handbook.name
+  enforce_admins = false
 
-#   required_status_checks {
-#     strict = true
-#   }
+  required_status_checks {
+    strict = true
+  }
 
-#   required_pull_request_reviews {
-#     dismiss_stale_reviews      = true
-#     require_code_owner_reviews = true
-#   }
-# }
+  required_pull_request_reviews {
+    dismiss_stale_reviews      = true
+    require_code_owner_reviews = true
+  }
+}
 
 resource "github_issue_label" "burendo_handbook" {
   for_each   = { for common_label in local.common_labels : common_label.name => common_label }

--- a/burendo-identity.tf
+++ b/burendo-identity.tf
@@ -31,22 +31,20 @@ resource "github_team_repository" "burendo_identity_admin" {
   permission = "admin"
 }
 
-# Commented out until we establish the Pro license
+resource "github_branch_protection" "burendo_identity_main" {
+  pattern        = github_repository.burendo_identity.default_branch
+  repository_id  = github_repository.burendo_identity.name
+  enforce_admins = false
 
-# resource "github_branch_protection" "burendo_identity_main" {
-#   pattern        = github_repository.burendo_identity.default_branch
-#   repository_id  = github_repository.burendo_identity.name
-#   enforce_admins = false
+  required_status_checks {
+    strict = true
+  }
 
-#   required_status_checks {
-#     strict = true
-#   }
-
-#   required_pull_request_reviews {
-#     dismiss_stale_reviews      = true
-#     require_code_owner_reviews = true
-#   }
-# }
+  required_pull_request_reviews {
+    dismiss_stale_reviews      = true
+    require_code_owner_reviews = true
+  }
+}
 
 resource "github_issue_label" "burendo_identity" {
   for_each   = { for common_label in local.common_labels : common_label.name => common_label }

--- a/burendo-secrets-config.tf
+++ b/burendo-secrets-config.tf
@@ -31,22 +31,20 @@ resource "github_team_repository" "burendo_secrets_config_admin" {
   permission = "admin"
 }
 
-# Commented out until we establish the Pro license
-#
-# resource "github_branch_protection" "burendo_secrets_config_main" {
-#   pattern        = github_repository.burendo_secrets_config.default_branch
-#   repository_id  = github_repository.burendo_secrets_config.name
-#   enforce_admins = false
+resource "github_branch_protection" "burendo_secrets_config_main" {
+  pattern        = github_repository.burendo_secrets_config.default_branch
+  repository_id  = github_repository.burendo_secrets_config.name
+  enforce_admins = false
 
-#   required_status_checks {
-#     strict   = true
-#   }
+  required_status_checks {
+    strict = true
+  }
 
-#   required_pull_request_reviews {
-#     dismiss_stale_reviews      = true
-#     require_code_owner_reviews = true
-#   }
-# }
+  required_pull_request_reviews {
+    dismiss_stale_reviews      = true
+    require_code_owner_reviews = true
+  }
+}
 
 resource "github_issue_label" "burendo_secrets_config" {
   for_each   = { for common_label in local.common_labels : common_label.name => common_label }


### PR DESCRIPTION
Now the GitHub Org has been upgraded, we can add branch protection to our private repos.