### PR TITLE
The checks use the job status not the workflow status

### DIFF
--- a/.github/workflows/tf-merge.yml
+++ b/.github/workflows/tf-merge.yml
@@ -98,15 +98,9 @@ jobs:
           name: prod-workflow-log
           path: ${{ github.workspace }}/${{ github.run_id }}-${{ github.run_number }}.log
 
-  report-failures:
-    name: Report Status
-    runs-on: ubuntu-latest
-    needs: production
-    if: always()
-    steps:
       - name: "Report Success"
         uses: ravsamhq/notify-slack-action@v1
-        if: success()
+        if: ${{ success() }}
         with:
           status: success
           notification_title: ':white_check_mark: *${{ github.workflow }} has succeeded* :white_check_mark:'
@@ -117,7 +111,7 @@ jobs:
   
       - name: "Report Failure"
         uses: ravsamhq/notify-slack-action@v1
-        if: failure()
+        if: ${{ failure() }}
         with:
           status: failure
           notification_title: ':alert: *${{ github.workflow }} has failed* :alert:'

--- a/.github/workflows/tf-merge.yml
+++ b/.github/workflows/tf-merge.yml
@@ -104,7 +104,7 @@ jobs:
         with:
           status: success
           notification_title: ':white_check_mark: *${{ github.workflow }} has succeeded* :white_check_mark:'
-          message_format: '_${{ github.workflow }}_ in ${{ github.repository }} was triggered by ${{ github.triggering_actor }}'
+          message_format: '_${{ github.workflow }}_ in *${{ github.repository }}* was triggered by ${{ github.triggering_actor }}'
           footer: 'Run id is ${{ github.run_id }}'
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_BUILD_NOTIFICATIONS_WEBHOOK }}
@@ -115,7 +115,7 @@ jobs:
         with:
           status: failure
           notification_title: ':alert: *${{ github.workflow }} has failed* :alert:'
-          message_format: '_${{ github.workflow }}_ in ${{ github.repository }} was triggered by ${{ github.triggering_actor }}'
+          message_format: '_${{ github.workflow }}_ in *${{ github.repository }}* was triggered by ${{ github.triggering_actor }}'
           footer: 'Run id is ${{ github.run_id }}'
           mention_groups: '${{ secrets.SLACK_ENGINEERING_GROUP_ID }}'
         env:


### PR DESCRIPTION
The checks use the job status not the workflow status so the report should be within the same job, not outside it or it reports false success