### PR TITLE
Add Gordon Brown to engineering team

### DIFF
--- a/membership.tf
+++ b/membership.tf
@@ -133,3 +133,9 @@ resource "github_team_membership" "engineering_membership_ann_barr" {
   username = "annjbarr"
   role     = "member"
 }
+
+resource "github_team_membership" "engineering_membership_gordon_brown" {
+  team_id  = github_team.engineering.id
+  username = "gordonbrown"
+  role     = "member"
+}

--- a/users.tf
+++ b/users.tf
@@ -111,3 +111,8 @@ resource "github_membership" "engineering_membership_ann_barr" {
   username = "annjbarr"
   role     = "member"
 }
+
+resource "github_membership" "engineering_membership_gordon_brown" {
+  username = "gordonbrown"
+  role     = "member"
+}


### PR DESCRIPTION
## Summary
- Adds gordonbrown to GitHub organization membership in users.tf
- Adds gordonbrown to engineering team in membership.tf

This will grant admin access to all repositories managed by this configuration.

## Test plan
- [ ] Review Terraform plan output in CI
- [ ] Verify no unexpected changes
- [ ] Apply and confirm user has appropriate access

🤖 Generated with [Claude Code](https://claude.com/claude-code)